### PR TITLE
[BUG] Animated: useNativeDriver was not specified.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -524,6 +524,7 @@ export default class ViewTransformer extends React.Component {
             {
                 toValue: 1,
                 duration: duration,
+                useNativeDriver: false,
                 easing: Easing.inOut(Easing.ease)
             }
         ).start();


### PR DESCRIPTION
This fixes the issue raised in https://github.com/Luehang/react-native-easy-view-transformer/issues/11

> Animated: useNativeDriver was not specified. This is a required option and must be explicitly set to true or false

